### PR TITLE
Controls refactoring: No more handlers in `Control`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### 9.0.0
+
+* Fix the major bug with `Path.pop` returning reverse result and, so, working with second-level panels;
+
 ### 8.0.1
 
 * New base font: `Oxanium`;

--- a/TODO.md
+++ b/TODO.md
@@ -4,6 +4,7 @@
     * Rename it to just `Value`, and put the definition into `Control` may be?
 * Breaking: Stick to just one `WithTron.Backed`, since anyway it is possible to convert one to another using `Tron` methods;
 * Breaking: Get rid of `maxRows` and `maxCols` in `PanelShape` and switch to manual pagination, do it only when user wants;
+* Breaking, Bug: Adjust default values in knobs/XY to the actual range, or else it is rendered improperly;
 * Ability to disable / enable pagination;
 * Detachable: Add `clientId` to the URL when it was generated (so that reloading the page won't lose changes);
 * Detachable: Hide the user view by default, when interface is detached;
@@ -22,6 +23,7 @@
 * Fix knobs to use current value when user starts dragging;
 * _Active_ condition for a button, some effect for when it is pressed;
 * Fix/improve knobs to support on-the-fly change of the value;
+* Vertical pagination;
 
 ## New controls
 

--- a/elm.json
+++ b/elm.json
@@ -6,6 +6,7 @@
     "version": "8.0.1",
     "exposed-modules": [
         "Tron",
+        "TronRef",
         "WithTron",
         "WithTron.Backed",
         "WithTron.ValueAt",

--- a/src/Tron.elm
+++ b/src/Tron.elm
@@ -3,7 +3,7 @@ module Tron exposing
     , map, mapSet, andThen, with
     )
 
-{-| This is the `Tron msg`, which is, similarly to `Html msg` or `Svg msg`, may send your messages into the lifecycle of your application. In this case, it represents your components.
+{-| This is the `Tron a`, which is, similarly to `Html msg` or `Svg msg`, may send your messages into the lifecycle of your application. In this case, it represents your components.
 
 To use Tron in your application, you'll need to specify this function:
 
@@ -25,30 +25,30 @@ See `WithTron` for the helpers to add `Tron` to your applcation.
 import Tron.Property as Property exposing (Property)
 
 
-{-| `Tron msg` is the tree of your controls or, recursively, any control in such tree.
+{-| `Tron a` is the tree of your controls or, recursively, any control in such tree.
 
 To build your interface, use the helpers from the `Tron.Builder` module or any of its variants like
 `Tron.Builder.Proxy`, `Tron.Builder.Unit` or `Tron.Builder.String`
 -}
-type alias Tron msg =
-    Property msg
+type alias Tron a =
+    Property a
 
 
 {-| `Set msg` is just the list of controls' definitions together with their labels.
 -}
-type alias Set msg =
-    List ( Property.Label, Tron msg )
+type alias Set a =
+    List ( Property.Label, Tron a )
 
 
 {-| The usual `map` function which allows you to substitute the messages sent through the components.
 -}
-map : (msgA -> msgB) -> Tron msgA -> Tron msgB
+map : (a -> b) -> Tron a -> Tron b
 map = Property.map
 
 
 {-| `andThen` without changing a message type
 -}
-andThen : (msg -> Tron msg) -> Tron msg -> Tron msg
+andThen : (a -> Tron a) -> Tron a -> Tron a
 andThen = Property.andThen
 
 
@@ -65,7 +65,7 @@ andThen = Property.andThen
         Product.compare
     |> Tron.shape (rows 3)
 -}
-with : (msg -> Tron msg -> Tron msg) -> Tron msg -> Tron msg
+with : (a -> Tron a -> Tron a) -> Tron a -> Tron a
 with = Property.with
 
 
@@ -90,7 +90,7 @@ with = Property.with
         toMsg
     |> cells CS.half
 -}
-mapSet : (msgA -> msgB) -> Set msgA -> Set msgB
+mapSet : (a -> b) -> Set a -> Set b
 mapSet =
     List.map << Tuple.mapSecond << map
 

--- a/src/Tron/Builder.elm
+++ b/src/Tron/Builder.elm
@@ -716,7 +716,7 @@ toSet : (a -> Label) -> List (Tron a) -> Set a
 toSet toLabel =
     List.map
         (\prop ->
-            Tron.Property.evaluate__ prop
+            Tron.Property.get prop
                 |> Maybe.map
                     (\v ->
                         ( toLabel v

--- a/src/Tron/Builder/Choice.elm
+++ b/src/Tron/Builder/Choice.elm
@@ -26,8 +26,6 @@ withButtons toLabel toButtonFace =
             <| Control
                 (toButtonFace val)
                 ()
-            <| Just
-            <| always
             <| callByIndex index
         )
 
@@ -64,7 +62,7 @@ helper ( panelShape, cellShape ) options current compare toMsg =
         values =
             options
                 |> Array.fromList
-                |> Array.map (Tuple.second >> Tron.Property.evaluate__)
+                |> Array.map (Tuple.second >> Tron.Property.get)
 
         currentIndex : Int
         currentIndex =
@@ -99,4 +97,4 @@ helper ( panelShape, cellShape ) options current compare toMsg =
                 , face = Nothing
                 , selected = currentIndex
                 }
-            <| Just (.selected >> callByIndex)
+            <| callByIndex currentIndex

--- a/src/Tron/Builder/Unit.elm
+++ b/src/Tron/Builder/Unit.elm
@@ -101,7 +101,7 @@ none = B.none
 
 {-| -}
 root : Set -> Tron
-root = B.root
+root set = B.root set ()
 
 
 {-| -}
@@ -161,7 +161,7 @@ bool = toggle
 
 {-| -}
 nest : Set -> Tron
-nest = B.nest
+nest set = B.nest set ()
 
 
 {-| -}

--- a/src/Tron/Control.elm
+++ b/src/Tron/Control.elm
@@ -13,9 +13,6 @@ map f (Control setup val a) =
     Control setup val <| f a
 
 
--- TODO: `map2`, `map3` etc.
-
-
 mapByValue : (value -> b) -> Control setup value a -> Control setup value b
 mapByValue f =
     reflect >> map (Tuple.first >> f)

--- a/src/Tron/Control.elm
+++ b/src/Tron/Control.elm
@@ -5,7 +5,7 @@ import Task
 
 
 type Control setup value a =
-    Control setup value a
+    Control setup value a -- TODO: `Maybe a`, for `Builder.root`, `Builder.nest` etc.
 
 
 map : (a -> b) -> Control setup value a -> Control setup value b
@@ -13,9 +13,17 @@ map f (Control setup val a) =
     Control setup val <| f a
 
 
--- mapWithValue : ((value, a) -> b) -> Control setup value a -> Control setup value b
--- mapWithValue f =
---     reflect >> map f
+-- TODO: `map2`, `map3` etc.
+
+
+mapByValue : (value -> b) -> Control setup value a -> Control setup value b
+mapByValue f =
+    reflect >> map (Tuple.first >> f)
+
+
+mapWithValue : ((value, a) -> b) -> Control setup value a -> Control setup value b
+mapWithValue f =
+    reflect >> map f
 
 
 andThen : (a -> Control setup value b) -> Control setup value a -> Control setup value b
@@ -55,6 +63,11 @@ fold f def control=
 reflect : Control s v a -> Control s v (v, a)
 reflect (Control s v a) =
     Control s v (v, a)
+
+
+move : Control s v a -> Control s v v
+move (Control s v _) =
+    Control s v v
 
 
 update : (v -> v) -> Control s v a -> Control s v a

--- a/src/Tron/Control.elm
+++ b/src/Tron/Control.elm
@@ -13,6 +13,11 @@ map f (Control setup val a) =
     Control setup val <| f a
 
 
+-- mapWithValue : ((value, a) -> b) -> Control setup value a -> Control setup value b
+-- mapWithValue f =
+--     reflect >> map f
+
+
 andThen : (a -> Control setup value b) -> Control setup value a -> Control setup value b
 andThen k (Control _ _ a) = k a
 
@@ -74,6 +79,10 @@ execute__ : ((v, a) -> msg) -> Control s v a -> Cmd msg
 execute__ handler (Control _ value a)  =
     Task.succeed (value, a)
         |> Task.perform handler
+
+
+run : Control s v msg -> Cmd msg
+run = execute identity
 
 
 get : Control s v a -> a

--- a/src/Tron/Control.elm
+++ b/src/Tron/Control.elm
@@ -89,7 +89,7 @@ execute handler =
 
 -- call control handler with the associated object
 execute__ : ((v, a) -> msg) -> Control s v a -> Cmd msg
-execute__ handler (Control _ value a)  =
+execute__ handler (Control _ value a) =
     Task.succeed (value, a)
         |> Task.perform handler
 

--- a/src/Tron/Control/Button.elm
+++ b/src/Tron/Control/Button.elm
@@ -20,7 +20,7 @@ type Face
     | WithColor Color
 
 
-type alias Control msg = Core.Control Face () msg
+type alias Control a = Core.Control Face () a
 
 
 withIcon : Icon -> Face
@@ -55,6 +55,6 @@ urlToString : Url -> String
 urlToString (Url str) = str
 
 
-setFace : Face -> Control msg -> Control msg
+setFace : Face -> Control a -> Control a
 setFace face (Core.Control _ val handler) =
     Core.Control face val handler

--- a/src/Tron/Control/Color.elm
+++ b/src/Tron/Control/Color.elm
@@ -6,4 +6,4 @@ import Color exposing (Color)
 import Tron.Control as Core exposing (Control)
 
 
-type alias Control msg = Core.Control () Color msg
+type alias Control a = Core.Control () Color a

--- a/src/Tron/Control/Nest.elm
+++ b/src/Tron/Control/Nest.elm
@@ -18,17 +18,17 @@ type Form
 type alias ItemId = Int
 
 
-type alias GroupControl item msg =
+type alias GroupControl item a =
     Core.Control
         ( Array item )
         { form : Form
         , face : Maybe Button.Face
         , page : PageNum
         }
-        msg
+        a
 
 
-type alias ChoiceControl item msg =
+type alias ChoiceControl item a =
     Core.Control
         ( Array item )
         { form : Form
@@ -36,7 +36,7 @@ type alias ChoiceControl item msg =
         , selected : ItemId
         , page : PageNum
         }
-        msg
+        a
 
 
 type alias Transient =
@@ -45,37 +45,37 @@ type alias Transient =
     }
 
 
-get : ItemId -> Core.Control ( Array item ) value msg -> Maybe item
+get : ItemId -> Core.Control ( Array item ) value a -> Maybe item
 get n = getItems >> Array.get n
 
 
-select : ItemId -> ChoiceControl item msg -> ChoiceControl item msg
+select : ItemId -> ChoiceControl item a -> ChoiceControl item a
 select index (Core.Control setup state handler) =
     Core.Control setup { state | selected = index } handler
 
 
-getSelected : ChoiceControl item msg -> Maybe item
+getSelected : ChoiceControl item a -> Maybe item
 getSelected control =
     get (whichSelected control) control
 
 
-isSelected : ChoiceControl item msg -> ItemId -> Bool
+isSelected : ChoiceControl item a -> ItemId -> Bool
 isSelected control n = whichSelected control == n
 
 
-whichSelected : ChoiceControl item msg -> ItemId
+whichSelected : ChoiceControl item a -> ItemId
 whichSelected (Core.Control _ { selected } handler) = selected
 
 
 expand
      : Core.Control
             setup
-            { a | form : Form }
-            msg
+            { r | form : Form }
+            a
     -> Core.Control
             setup
-            { a | form : Form }
-            msg
+            { r | form : Form }
+            a
 expand (Core.Control setup state handler) =
     Core.Control setup { state | form = Expanded } handler
 
@@ -83,12 +83,12 @@ expand (Core.Control setup state handler) =
 collapse
      : Core.Control
             setup
-            { a | form : Form }
-            msg
+            { r | form : Form }
+            a
     -> Core.Control
             setup
-            { a | form : Form }
-            msg
+            { r | form : Form }
+            a
 collapse (Core.Control setup state handler) =
     Core.Control setup { state | form = Collapsed } handler
 
@@ -96,12 +96,12 @@ collapse (Core.Control setup state handler) =
 detach
      : Core.Control
             setup
-            { a | form : Form }
-            msg
+            { r | form : Form }
+            a
     -> Core.Control
             setup
-            { a | form : Form }
-            msg
+            { r | form : Form }
+            a
 detach (Core.Control setup state handler) =
     Core.Control setup { state | form = Detached } handler
 
@@ -109,12 +109,12 @@ detach (Core.Control setup state handler) =
 toggle
      : Core.Control
             setup
-            { a | form : Form }
-            msg
+            { r | form : Form }
+            a
     -> Core.Control
             setup
-            { a | form : Form }
-            msg
+            { r | form : Form }
+            a
 toggle (Core.Control setup state handler) =
     Core.Control
         setup
@@ -128,22 +128,22 @@ toggle (Core.Control setup state handler) =
         handler
 
 
-getForm : Core.Control setup { a | form : Form } msg -> Form
+getForm : Core.Control setup { r | form : Form } a -> Form
 getForm (Core.Control _ { form } _) = form
 
 
-is : Form -> Core.Control setup { a | form : Form } msg -> Bool
+is : Form -> Core.Control setup { r | form : Form } a -> Bool
 is checkedForm (Core.Control _ { form } _) = checkedForm == form
 
 
-getItems : Core.Control ( Array item ) value msg -> Array item
+getItems : Core.Control ( Array item ) value a -> Array item
 getItems (Core.Control items _ _) = items
 
 
 setItems
      : Array item
-    -> Core.Control ( Array item ) value msg
-    -> Core.Control ( Array item ) value msg
+    -> Core.Control ( Array item ) value a
+    -> Core.Control ( Array item ) value a
 setItems newItems (Core.Control _ value handler) =
     Core.Control newItems value handler
 
@@ -153,11 +153,11 @@ mapItems
     -> Core.Control
             ( Array itemA )
             value
-            msg
+            a
     -> Core.Control
             ( Array itemB )
             value
-            msg
+            a
 mapItems f (Core.Control items value handler) =
     Core.Control ( items |> Array.map f ) value handler
 
@@ -167,11 +167,11 @@ indexedMapItems
     -> Core.Control
             ( Array itemA )
             value
-            msg
+            a
     -> Core.Control
             ( Array itemB )
             value
-            msg
+            a
 indexedMapItems f (Core.Control items value handler) =
     Core.Control ( items |> Array.indexedMap f ) value handler
 
@@ -179,8 +179,8 @@ indexedMapItems f (Core.Control items value handler) =
 withItem
      : Int
     -> (item -> item)
-    -> Core.Control (Array item) value msg
-    -> Core.Control (Array item) value msg
+    -> Core.Control (Array item) value a
+    -> Core.Control (Array item) value a
 withItem id f ( Core.Control items state handler ) =
     Core.Control
         ( case Array.get id items of
@@ -192,14 +192,14 @@ withItem id f ( Core.Control items state handler ) =
         state
         handler
 
-getPage : Core.Control setup { a | page : PageNum } msg -> PageNum
+getPage : Core.Control setup { r | page : PageNum } a -> PageNum
 getPage (Core.Control _ { page } _) = page
 
 
 switchTo
     :  PageNum
-    -> Core.Control setup { a | page : PageNum } msg
-    -> Core.Control setup { a | page : PageNum } msg
+    -> Core.Control setup { r | page : PageNum } a
+    -> Core.Control setup { r | page : PageNum } a
 switchTo pageNum (Core.Control setup state hanlder) =
     Core.Control
         setup
@@ -210,10 +210,10 @@ switchTo pageNum (Core.Control setup state hanlder) =
 getTransientState
     : Core.Control
         setup
-        { a | form : Form
+        { r | form : Form
         , page : PageNum
         }
-        msg
+        a
     -> Transient
 getTransientState (Core.Control _ state _) =
     { form = state.form
@@ -224,19 +224,19 @@ getTransientState (Core.Control _ state _) =
 restoreTransientState
     :  Core.Control
         setup
-        { a
+        { r
         | form : Form
         , page : PageNum
         }
-        msg
+        a
     -> Transient
     -> Core.Control
         setup
-        { a
+        { r
         | form : Form
         , page : PageNum
         }
-        msg
+        a
 restoreTransientState (Core.Control setup state handler) src =
     Core.Control
         setup
@@ -251,12 +251,12 @@ setFace
      : Button.Face
     -> Core.Control
             setup
-            { a | face : Maybe Button.Face }
-            msg
+            { r | face : Maybe Button.Face }
+            a
     -> Core.Control
             setup
-            { a | face : Maybe Button.Face }
-            msg
+            { r | face : Maybe Button.Face }
+            a
 setFace face (Core.Control setup state handler) =
     Core.Control setup { state | face = Just face } handler
 
@@ -264,18 +264,18 @@ setFace face (Core.Control setup state handler) =
 clearFace
      : Core.Control
             setup
-            { a | face : Maybe Button.Face }
-            msg
+            { r | face : Maybe Button.Face }
+            a
     -> Core.Control
             setup
-            { a | face : Maybe Button.Face }
-            msg
+            { r | face : Maybe Button.Face }
+            a
 clearFace (Core.Control setup state handler) =
     Core.Control setup { state | face = Nothing } handler
 
 
-toChoice : (ItemId -> msg) -> GroupControl item msg -> ChoiceControl item msg
-toChoice userHandler (Core.Control items { form, page, face } _) =
+toChoice : GroupControl item a -> ChoiceControl item a
+toChoice (Core.Control items { form, page, face } a) =
     Core.Control
         items
         { form = form
@@ -283,4 +283,4 @@ toChoice userHandler (Core.Control items { form, page, face } _) =
         , face = face
         , selected = 0
         }
-        (Just <| .selected >> userHandler)
+        a

--- a/src/Tron/Control/Number.elm
+++ b/src/Tron/Control/Number.elm
@@ -10,5 +10,5 @@ import Svg.Attributes as SA exposing (..)
 import Tron.Control as Core exposing (Control)
 
 
-type alias Control msg = Core.Control Axis Float msg
+type alias Control a = Core.Control Axis Float a
 

--- a/src/Tron/Control/Text.elm
+++ b/src/Tron/Control/Text.elm
@@ -10,33 +10,33 @@ type TextState
     | Editing
 
 
-type alias Control msg = Core.Control () ( TextState, String ) msg
+type alias Control a = Core.Control () ( TextState, String ) a
 
 
 type alias Transient =
     TextState
 
 
-ensureEditing : Control msg -> Control msg
+ensureEditing : Control a -> Control a
 ensureEditing =
     Control.update <| \(_, v) -> ( Editing, v )
 
 
-finishEditing : Control msg -> Control msg
+finishEditing : Control a -> Control a
 finishEditing =
     Control.update <| \(_, v) -> ( Ready, v )
 
 
-updateText : String -> Control msg -> Control msg
+updateText : String -> Control a -> Control a
 updateText newValue =
     update
         <| \(s, _) -> ( s, newValue )
 
 
-getTransientState : Control msg -> Transient
+getTransientState : Control a -> Transient
 getTransientState (Core.Control _ ( state, _ ) _) = state
 
 
-restoreTransientState : Control msg -> Transient -> Control msg
+restoreTransientState : Control a -> Transient -> Control a
 restoreTransientState (Control setup ( _, val ) handler) state =
     Core.Control setup ( state, val ) handler

--- a/src/Tron/Control/Toggle.elm
+++ b/src/Tron/Control/Toggle.elm
@@ -10,10 +10,10 @@ type ToggleState
     | TurnedOff
 
 
-type alias Control msg = Core.Control () ToggleState msg
+type alias Control a = Core.Control () ToggleState a
 
 
-toggle : Control msg -> Control msg
+toggle : Control a -> Control a
 toggle =
     Control.update
         <| \current ->
@@ -22,12 +22,12 @@ toggle =
                 TurnedOn -> TurnedOff
 
 
-toggleOn : Control msg -> Control msg
+toggleOn : Control a -> Control a
 toggleOn =
     Control.update <| always TurnedOn
 
 
-toggleOff : Control msg -> Control msg
+toggleOff : Control a -> Control a
 toggleOff =
     Control.update <| always TurnedOff
 

--- a/src/Tron/Control/XY.elm
+++ b/src/Tron/Control/XY.elm
@@ -6,7 +6,7 @@ import Axis exposing (Axis)
 import Tron.Control as Core exposing (Control)
 
 
-type alias Control msg = Core.Control ( Axis, Axis ) ( Float, Float ) msg
+type alias Control a = Core.Control ( Axis, Axis ) ( Float, Float ) a
 
 
 separator : String

--- a/src/Tron/Core.elm
+++ b/src/Tron/Core.elm
@@ -124,7 +124,6 @@ update msg state tree  =
                     tree
                         |> executeAt path
                         --|> List.map (Tuple.mapSecond Exp.toExposed)
-                        |> Debug.log "executed"
                 nextRoot =
                     tree |> updateMany updates
             in

--- a/src/Tron/Core.elm
+++ b/src/Tron/Core.elm
@@ -25,7 +25,7 @@ import Tron.Path as Path
 import Tron.Control exposing (..)
 import Tron.Control.Text as Text
 import Tron.Property exposing (..)
-import Tron.Property as Property exposing (call, find)
+import Tron.Property as Property exposing (run, find)
 import Tron.Layout exposing (Layout)
 import Tron.Layout as Layout exposing (..)
 import Tron.Msg exposing (..)
@@ -197,7 +197,7 @@ update msg gui =
                     | tree = nextRoot
                     }
                 , updates
-                    |> List.map (Tuple.second >> Property.call)
+                    |> List.map (Tuple.second >> Property.run)
                     |> Cmd.batch
                 )
 
@@ -415,9 +415,9 @@ handleMouse mouseAction gui =
 
                             Just ( _, prop ) ->
                                 case prop of
-                                    Number _ -> Property.call prop
-                                    Coordinate _ -> Property.call prop
-                                    Color _ -> Property.call prop
+                                    Number _ -> Property.run prop
+                                    Coordinate _ -> Property.run prop
+                                    Color _ -> Property.run prop
                                     _ -> Cmd.none
                             Nothing -> Cmd.none
 
@@ -453,7 +453,7 @@ handleKeyDown keyCode path gui =
                     | tree = nextRoot
                     }
                 , updates
-                    |> List.map (Tuple.second >> Property.call)
+                    |> List.map (Tuple.second >> Property.run)
                     |> Cmd.batch
                     |> Cmd.map (Tuple.pair path)
                 )
@@ -490,7 +490,7 @@ handleKeyDown keyCode path gui =
                                     |> setAt path nextProp
                             }
                         -- FIXME: inside, we check if it is a text prop again
-                        , Property.call nextProp
+                        , Property.run nextProp
                             |> Cmd.map (Tuple.pair path)
                         )
                 _ -> executeByPath ()

--- a/src/Tron/Core.elm
+++ b/src/Tron/Core.elm
@@ -230,7 +230,7 @@ handleMouse mouseAction state tree =
         nextMouseState =
             state.mouse
                 |> Tron.Mouse.apply mouseAction
-        size = getSizeInCells state
+        size = getSizeInCells state tree
         bounds =
             Dock.boundsFromSize state.dock state.viewport size
         theLayout =
@@ -478,7 +478,7 @@ getRootPath gui =
         |> Maybe.withDefault Path.start
 
 
-sizeFromViewport : Property msg -> Size Pixels -> Size Cells
+sizeFromViewport : Property a -> Size Pixels -> Size Cells
 sizeFromViewport _ (Size ( widthInPixels, heightInPixels )) =
     {- let
         cellsFitHorizontally = floor (toFloat widthInPixels / Cell.width)
@@ -490,19 +490,19 @@ sizeFromViewport _ (Size ( widthInPixels, heightInPixels )) =
 
 
 
-getSizeInCells : State -> Size Cells
-getSizeInCells gui =
-    case gui.size of
+getSizeInCells : State -> Tron a -> Size Cells
+getSizeInCells state tree =
+    case state.size of
         Just userSize -> userSize
         Nothing ->
-            gui.viewport
-                |> sizeFromViewport gui.tree
+            state.viewport
+                |> sizeFromViewport tree
 
 
-layout : State -> Tron () -> ( Tron (), Layout )
+layout : State -> Tron a -> ( Tron a, Layout )
 layout state tree =
     let
-        ( Size cellsSize ) = getSizeInCells state
+        ( Size cellsSize ) = getSizeInCells state tree
         size = cellsSize |> Tuple.mapBoth toFloat toFloat |> SizeF
     in
     case state.detach
@@ -529,10 +529,10 @@ subscriptions _ =
         ]
 
 
-view : Theme -> State -> Tron () -> Html Msg
+view : Theme -> State -> Tron a -> Html Msg
 view theme state tree  =
     let
-        cellsSize = getSizeInCells state
+        cellsSize = getSizeInCells state tree
         bounds =
             Dock.boundsFromSize state.dock state.viewport cellsSize
         detachState = Tuple.second state.detach

--- a/src/Tron/Core.elm
+++ b/src/Tron/Core.elm
@@ -2,7 +2,7 @@ module Tron.Core exposing
     ( State, Msg
     , view, update, init, subscriptions, run
     , dock, reshape
-    , applyRaw
+    , applyRaw, invalidate
     )
 
 

--- a/src/Tron/Core.elm
+++ b/src/Tron/Core.elm
@@ -51,12 +51,12 @@ import Tron.Expose.Data as Exp
 import Tron.Expose.Convert as Exp
 
 
-type alias Model msg =
+type alias Model a =
     { dock : Dock
     , viewport : Size Pixels
     , size : Maybe (Size Cells)
     , mouse : MouseState
-    , tree : Tron msg
+    , tree : Tron a
     , detach : ( Maybe ClientId, Detach.State )
     , hidden : Bool
     }

--- a/src/Tron/Core.elm
+++ b/src/Tron/Core.elm
@@ -107,7 +107,7 @@ run =
 update
     :  Msg
     -> State
-    -> Tron ( Exp.ProxyValue -> msg )
+    -> Tron ( Exp.ProxyValue -> Maybe msg )
     -> ( State, Tron (), Cmd msg )
 update msg state tree  =
     case msg of
@@ -185,7 +185,7 @@ update msg state tree  =
 
 applyRaw
      : Exp.RawInUpdate
-    -> Tron (Exp.ProxyValue -> msg)
+    -> Tron (Exp.ProxyValue -> Maybe msg)
     -> Cmd msg
 applyRaw rawUpdate =
     Exp.apply (Exp.fromPort rawUpdate)
@@ -220,7 +220,7 @@ trackMouse =
 
 
 -- FIXME: return actual updates with values, then somehow extract messages from `Tron msg` for these values?
-handleMouse : MouseAction -> State -> Tron ( Exp.ProxyValue -> msg ) -> ( State, Tron (), Cmd msg )
+handleMouse : MouseAction -> State -> Tron ( Exp.ProxyValue -> Maybe msg ) -> ( State, Tron (), Cmd msg )
 handleMouse mouseAction state tree =
     let
         rootPath = getRootPath state
@@ -359,7 +359,7 @@ handleKeyDown
     :  Int
     -> Path
     -> State
-    -> Tron (Exp.ProxyValue -> msg)
+    -> Tron (Exp.ProxyValue -> Maybe msg)
     -> ( State, Tron (), Cmd msg )
 handleKeyDown keyCode path state tree =
     let

--- a/src/Tron/Expose.elm
+++ b/src/Tron/Expose.elm
@@ -789,6 +789,11 @@ reflect prop =
                 <| reflectWith (always Other) <| control
 
 
+lift : Property a -> Property (ProxyValue -> Maybe a)
+lift =
+    Property.map (always << Just)
+
+
 freshRun : Property (ProxyValue -> Maybe msg) -> Cmd msg
 freshRun =
     evaluate

--- a/src/Tron/Expose.elm
+++ b/src/Tron/Expose.elm
@@ -755,56 +755,11 @@ decodeToggle =
         ]
 
 
-reflect : Property a -> Property ( ProxyValue, a )
-reflect prop =
-    let
-        reflectWith toProxy_ =
-            Control.reflect
-                >> Control.map (Tuple.mapFirst toProxy_)
-    in case prop of
-        Nil -> Nil
-        Number control ->
-            Number <| reflectWith FromSlider <| control
-        Coordinate control ->
-            Coordinate <| reflectWith FromXY <| control
-        Text control ->
-            Text
-                <| Control.map (Tuple.mapFirst Tuple.second >> Tuple.mapFirst FromInput)
-                <| Control.reflect
-                <| control
-        Color control ->
-            Color <| reflectWith FromColor <| control
-        Toggle control ->
-            Toggle <| reflectWith FromToggle <| control
-        Action control ->
-            Action <| reflectWith (always FromButton) <| control
-        Choice focus shape control ->
-            Choice focus shape
-                <| Nest.mapItems (Tuple.mapSecond reflect)
-                <| reflectWith (.selected >> FromChoice)
-                <| control
-        Group focus shape control ->
-            Group focus shape
-                <| Nest.mapItems (Tuple.mapSecond reflect)
-                <| reflectWith (always Other) <| control
-
-
-lift : Property a -> Property (ProxyValue -> Maybe a)
-lift =
-    Property.map (always << Just)
-
-
 freshRun : Property (ProxyValue -> Maybe msg) -> Cmd msg
 freshRun =
     evaluate
     -- >> Property.run
     >> runMaybe
-
-
-evaluate : Property (ProxyValue -> Maybe msg) -> Property (Maybe msg)
-evaluate =
-    reflect
-    >> Property.map (\(v, handler) -> handler v)
 
 
 runMaybe : Property (Maybe msg) -> Cmd msg

--- a/src/Tron/Expose.elm
+++ b/src/Tron/Expose.elm
@@ -654,6 +654,9 @@ fromPort portUpdate =
         } -}
 
 
+
+-- TODO: move functions below to `Expose.Convert` module?
+
 swap : RawOutUpdate -> RawInUpdate
 swap outUpdate =
     { path = outUpdate.path

--- a/src/Tron/Expose.elm
+++ b/src/Tron/Expose.elm
@@ -30,32 +30,32 @@ updateProperty value property =
             Cmd.none
 
         ( Number control, FromSlider f ) ->
-            f |> callWith control
+            control |> setValue f |> Control.run
 
         ( Coordinate control, FromXY xy ) ->
-            xy |> callWith control
+            control |> setValue xy |> Control.run
 
         ( Text control, FromInput s ) ->
-            ( Ready, s ) |> callWith control
+            control |> setValue ( Ready, s ) |> Control.run
 
         ( Color control, FromColor c ) ->
-            c |> callWith control
+            control |> setValue c |> Control.run
 
         ( Toggle control, FromToggle t ) ->
-            t |> callWith control
+            control |> setValue t |> Control.run
 
         ( Action control, FromButton ) ->
-            () |> callWith control
+            control |> setValue () |> Control.run
 
         ( Choice _ _ control, FromChoice i ) ->
-            let
-                curValue =
-                    Control.getValue control
-            in
-            { curValue
-                | selected = i
-            }
-                |> callWith control
+            control
+                |> Control.update
+                    (\curValue ->
+                        { curValue
+                            | selected = i
+                        }
+                    )
+                |> Control.run
 
         ( Group _ _ _, _ ) ->
             Cmd.none

--- a/src/Tron/Expose.elm
+++ b/src/Tron/Expose.elm
@@ -21,6 +21,7 @@ import Tron.Property as Property exposing (..)
 import Tron.Expose.ProxyValue as ProxyValue exposing (ProxyValue(..))
 import Tron.Expose.Data exposing (..)
 import Tron.Expose.Convert exposing (..)
+import Tron.Util as Util
 
 
 runProperty : ProxyValue -> Property msg -> Cmd msg
@@ -787,8 +788,11 @@ reflect prop =
                 <| reflectWith (always Other) <| control
 
 
-freshRun : Property (ProxyValue -> msg) -> Cmd msg
+freshRun : Property (ProxyValue -> Maybe msg) -> Cmd msg
 freshRun =
     reflect
     >> Property.map (\(v, handler) -> handler v)
-    >> Property.run
+    -- >> Property.run
+    >> Property.get
+    >> Maybe.andThen identity
+    >> Util.runMaybe

--- a/src/Tron/Expose/Convert.elm
+++ b/src/Tron/Expose/Convert.elm
@@ -106,12 +106,11 @@ the required information about the value, such as:
 Use `Builder.map Tuple.first` to get rid of the message if you don't need it.
 -}
 toExposed : Tron msg -> Tron ( RawOutUpdate, msg )
-toExposed prop =
-    prop
-        |> toProxied
-        |> Property.addPaths
+toExposed =
+    toProxied
+        >> Property.addPaths
         -- FIXME: `Expose.encodeUpdate` does the same as above
-        |> Property.map
+        >> Property.map
             (\( ( path, labelPath ), ( proxyVal, msg ) ) ->
                 ( { path = Path.toList path
                   , labelPath = labelPath
@@ -134,11 +133,10 @@ together with message.
 Use `Builder.map Tuple.first` to get rid of the message if you don't need it.
 -}
 toStrExposed : Tron msg -> Tron ( ( LabelPath, String ), msg )
-toStrExposed prop =
-    prop
-        |> toProxied
-        |> Property.addLabeledPath
-        |> Property.map
+toStrExposed =
+    toProxied
+        >> Property.addLabeledPath
+        >> Property.map
             (\( path, ( proxyVal, msg ) ) ->
                 ( ( path
                   , ProxyValue.toString proxyVal
@@ -187,7 +185,7 @@ lift =
     Property.map (always << Just)
 
 
-evaluate : Property (ProxyValue -> Maybe msg) -> Property (Maybe msg)
+evaluate : Property (ProxyValue -> Maybe a) -> Property (Maybe a)
 evaluate =
     reflect
     >> Property.map (\(v, handler) -> handler v)

--- a/src/Tron/Expose/ProxyValue.elm
+++ b/src/Tron/Expose/ProxyValue.elm
@@ -1,5 +1,5 @@
 module Tron.Expose.ProxyValue exposing
-    ( ProxyValue(..)
+    ( ProxyValue(..), get
     , encode
     , toString, getTypeString
     , toggleToBool, toggleToString
@@ -209,3 +209,17 @@ fromColor proxy =
     case proxy of
         FromColor color -> Just color
         _ -> Nothing
+
+
+get : Property a -> ProxyValue
+get prop =
+    case prop of
+        Nil -> Other
+        Number control -> control |> Control.getValue |> FromSlider
+        Coordinate control -> control |> Control.getValue |> FromXY
+        Text control -> control |> Control.getValue |> Tuple.second |> FromInput
+        Color control -> control |> Control.getValue |> FromColor
+        Toggle control -> control |> Control.getValue |> FromToggle
+        Action _ -> FromButton
+        Choice _ _ control -> control |> Control.getValue |> .selected |> FromChoice
+        Group _ _ _ -> Other

--- a/src/Tron/Expose/ProxyValue.elm
+++ b/src/Tron/Expose/ProxyValue.elm
@@ -4,7 +4,6 @@ module Tron.Expose.ProxyValue exposing
     , toString, getTypeString
     , toggleToBool, toggleToString
     , fromNumber, fromXY, fromText, fromChoice, fromChoiceOf, fromColor, fromToggle, fromAction
-    , reflect
     )
 
 
@@ -210,37 +209,3 @@ fromColor proxy =
     case proxy of
         FromColor color -> Just color
         _ -> Nothing
-
-
-reflect : Property a -> Property ( ProxyValue, a )
-reflect prop =
-    let
-        reflectWith toProxy =
-            Control.reflect
-                >> Control.map (Tuple.mapFirst toProxy)
-    in case prop of
-        Nil -> Nil
-        Number control ->
-            Number <| reflectWith FromSlider <| control
-        Coordinate control ->
-            Coordinate <| reflectWith FromXY <| control
-        Text control ->
-            Text
-                <| Control.map (Tuple.mapFirst Tuple.second >> Tuple.mapFirst FromInput)
-                <| Control.reflect
-                <| control
-        Color control ->
-            Color <| reflectWith FromColor <| control
-        Toggle control ->
-            Toggle <| reflectWith FromToggle <| control
-        Action control ->
-            Action <| reflectWith (always FromButton) <| control
-        Choice focus shape control ->
-            Choice focus shape
-                <| Nest.mapItems (Tuple.mapSecond reflect)
-                <| reflectWith (.selected >> FromChoice)
-                <| control
-        Group focus shape control ->
-            Group focus shape
-                <| Nest.mapItems (Tuple.mapSecond reflect)
-                <| reflectWith (always Other) <| control

--- a/src/Tron/Layout.elm
+++ b/src/Tron/Layout.elm
@@ -85,11 +85,11 @@ find ( _, layout ) { x, y } =
             Nothing
 
 
-pack : Dock -> SizeF Cells -> Property msg -> Layout
+pack : Dock -> SizeF Cells -> Property a -> Layout
 pack dock size_ = pack1 dock size_ Path.start
 
 
-pack1 : Dock -> SizeF Cells -> Path -> Property msg -> Layout
+pack1 : Dock -> SizeF Cells -> Path -> Property a -> Layout
 pack1 dock size_ rootPath prop =
     case prop of
         Nil ->
@@ -126,7 +126,7 @@ packItemsAtRoot
     -> SizeF Cells
     -> Path
     -> PanelShape
-    -> Array (Property msg)
+    -> Array (Property a)
     -> SmartPack (Cell_ Path)
 packItemsAtRoot dock size_ rp shape items =
     let
@@ -276,9 +276,9 @@ packItemsAtRoot dock size_ rp shape items =
             -> Position
             -> SmartPack (Cell_ Path)
             -> Control
-                    ( Array ( Label, Property msg ) )
-                    { a | form : Form, page : PageNum }
-                    msg
+                    ( Array ( Label, Property a ) )
+                    { r | form : Form, page : PageNum }
+                    a
             -> SmartPack (Cell_ Path)
         packGroupControl
             path

--- a/src/Tron/Path.elm
+++ b/src/Tron/Path.elm
@@ -46,18 +46,13 @@ equal (Path p1) (Path p2) = p1 == p2
 
 pop : Path -> Maybe ( Path, Int )
 pop (Path l) =
-    let
-        reversed = List.reverse l
-    in
-        List.head reversed
-            |> Maybe.map
-                (\deepest ->
-                    ( List.tail reversed
-                        |> Maybe.withDefault []
-                        |> fromList
-                    , deepest
-                    )
-                )
+    case List.reverse l of
+        [] ->
+            Nothing
+
+        last_ :: rest ->
+            ( Path <| List.reverse rest, last_ )
+                |> Just
 
 
 last : Path -> Maybe Int

--- a/src/Tron/Property.elm
+++ b/src/Tron/Property.elm
@@ -455,7 +455,7 @@ executeAt path root =
         Nothing -> []
 
 
-transferTransientState : Property a -> Property a -> Property a
+transferTransientState : Property a -> Property b -> Property b
 transferTransientState propA propB =
     let
         f propA_ propB_ =

--- a/src/Tron/Property.elm
+++ b/src/Tron/Property.elm
@@ -752,7 +752,8 @@ compareValues propA propB =
         (Toggle controlA, Toggle controlB) ->
             Control.getValue controlA == Control.getValue controlB
         (Action _, Action _) -> True
-        (Choice _ _ _, Choice _ _ _) -> True
+        (Choice _ _ controlA, Choice _ _ controlB) ->
+            Nest.whichSelected controlA == Nest.whichSelected controlB
         (Group _ _ _, Group _ _ _) -> True
         (_, _) -> False
 
@@ -852,3 +853,31 @@ move f propA propB =
                     Group focus shape <| Nest.setItems (zipItems controlA controlB) <| control
                 otherProp -> otherProp
         _ -> f propA propB
+
+
+setValueTo : Property a -> Property b -> Property b
+setValueTo from to =
+    case ( from, to ) of
+        (Number controlA, Number controlB) ->
+            Number <| Control.setValue (Control.getValue controlA) <| controlB
+        (Coordinate controlA, Coordinate controlB) ->
+            Coordinate <| Control.setValue (Control.getValue controlA) <| controlB
+        (Text controlA, Text controlB) ->
+            Text <| Control.setValue (Control.getValue controlA) <| controlB
+        (Color controlA, Color controlB) ->
+            Color <| Control.setValue (Control.getValue controlA) <| controlB
+        (Toggle controlA, Toggle controlB) ->
+            Toggle <| Control.setValue (Control.getValue controlA) <| controlB
+        (Choice _ _ controlA, Choice focus shape controlB) ->
+            Choice focus shape <| Control.setValue (Control.getValue controlA) <| controlB
+        (Group _ _ controlA, Group focus shape controlB) ->
+            Group focus shape <| Control.setValue (Control.getValue controlA) <| controlB
+        (_, _) -> to
+
+
+
+-- map2 use `move` for that
+
+
+loadValues : Property a -> Property b -> Property b
+loadValues = move setValueTo

--- a/src/Tron/Property.elm
+++ b/src/Tron/Property.elm
@@ -654,20 +654,6 @@ noGhosts : List (Property a) -> List (Property a)
 noGhosts = List.filter (not << isGhost)
 
 
-reflect : Property a -> Maybe a
-reflect prop =
-    case prop of
-        Nil -> Nothing
-        Number control -> control |> Control.get |> Just
-        Coordinate control -> control |> Control.get |> Just
-        Text control -> control |> Control.get |> Just
-        Color control -> control |> Control.get |> Just
-        Toggle control -> control |> Control.get |> Just
-        Action control -> control |> Control.get |> Just
-        Choice _ _ control -> control |> Control.get |> Just
-        Group _ _ control -> control |> Control.get |> Just
-
-
 run : Property msg -> Cmd msg
 run prop =
     case prop of

--- a/src/Tron/Property.elm
+++ b/src/Tron/Property.elm
@@ -131,7 +131,7 @@ findAll path root =
         helper (Path.toList path) ( "", root )
 
 
-map : (aA -> aB) -> Property aA -> Property aB
+map : (a -> b) -> Property a -> Property b
 map f prop =
     case prop of
         Nil -> Nil
@@ -158,10 +158,10 @@ map f prop =
 
 
 {- zip
-    : (Property aA -> Property aB -> Property aC)
-    -> Property aA
-    -> Property aB
-    -> Property aC
+    : (Property a -> Property b -> Property c)
+    -> Property a
+    -> Property b
+    -> Property c
 zip f propA propB =
     case ( propA, propB ) of
         ( Choice _ _ controlA, Choice _ _ controlB ) ->
@@ -241,28 +241,28 @@ replaceWithLabeledPath =
 
 -- aren't `...Map` functions are compositions like `replace << map`?
 replaceMap
-    :  (Path -> aA -> aB)
-    -> (Path -> Property aB -> Property aB)
-    -> Property aA
-    -> Property aB
+    :  (Path -> a -> b)
+    -> (Path -> Property b -> Property b)
+    -> Property a
+    -> Property b
 replaceMap aMap f =
     replaceWithPathsMap (Tuple.first >> aMap) (Tuple.first >> f)
 
 
 replaceWithLabeledPathMap
-    :  (LabelPath -> aA -> aB)
-    -> (LabelPath -> Property aB -> Property aB)
-    -> Property aA
-    -> Property aB
+    :  (LabelPath -> a -> b)
+    -> (LabelPath -> Property b -> Property b)
+    -> Property a
+    -> Property b
 replaceWithLabeledPathMap aMap f =
     replaceWithPathsMap (Tuple.second >> aMap) (Tuple.second >> f)
 
 
 replaceWithPathsMap
-    :  (( Path, LabelPath ) -> aA -> aB)
-    -> (( Path, LabelPath ) -> Property aB -> Property aB)
-    -> Property aA
-    -> Property aB
+    :  (( Path, LabelPath ) -> a -> b)
+    -> (( Path, LabelPath ) -> Property b -> Property b)
+    -> Property a
+    -> Property b
 replaceWithPathsMap aMap f root =
     -- FIXME: should be just another `fold` actually?
 
@@ -271,8 +271,8 @@ replaceWithPathsMap aMap f root =
         replaceItem
             :  ( Path, LabelPath )
             -> Int
-            -> ( Label, Property aA )
-            -> ( Label, Property aB )
+            -> ( Label, Property a )
+            -> ( Label, Property b )
         replaceItem ( parentPath, parentLabelPath ) index ( label, innerItem ) =
             ( label
             , helper
@@ -282,7 +282,7 @@ replaceWithPathsMap aMap f root =
                 innerItem
             )
 
-        helper : ( Path, LabelPath ) -> Property aA -> Property aB
+        helper : ( Path, LabelPath ) -> Property a -> Property b
         helper curPath item =
             case item of
                 Choice focus shape control ->
@@ -654,20 +654,32 @@ noGhosts : List (Property a) -> List (Property a)
 noGhosts = List.filter (not << isGhost)
 
 
-{-}
 call : Property msg -> Cmd msg
 call prop =
     case prop of
         Nil -> Cmd.none
-        Number control -> control |> Control.execute identity
-        Coordinate control -> control |> Control.execute identity
-        Text control -> control |> Control.execute identity
-        Color control -> control |> Control.execute identity
-        Toggle control -> control |> Control.execute identity
-        Action control -> control |> Control.execute identity
-        Choice _ _ control -> control |> Control.execute identity
-        Group _ _ control -> control |> Control.execute identity
--}
+        Number control -> control |> Control.run
+        Coordinate control -> control |> Control.run
+        Text control -> control |> Control.run
+        Color control -> control |> Control.run
+        Toggle control -> control |> Control.run
+        Action control -> control |> Control.run
+        Choice _ _ control -> control |> Control.run
+        Group _ _ control -> control |> Control.run
+
+
+get : Property a -> Maybe a
+get prop =
+    case prop of
+        Nil -> Nothing
+        Number control -> control |> Control.get |> Just
+        Coordinate control -> control |> Control.get |> Just
+        Text control -> control |> Control.get |> Just
+        Color control -> control |> Control.get |> Just
+        Toggle control -> control |> Control.get |> Just
+        Action control -> control |> Control.get |> Just
+        Choice _ _ control -> control |> Control.get |> Just
+        Group _ _ control -> control |> Control.get |> Just
 
 
 getCellShape : Property a -> Maybe CellShape

--- a/src/Tron/Property.elm
+++ b/src/Tron/Property.elm
@@ -654,8 +654,22 @@ noGhosts : List (Property a) -> List (Property a)
 noGhosts = List.filter (not << isGhost)
 
 
-call : Property msg -> Cmd msg
-call prop =
+reflect : Property a -> Maybe a
+reflect prop =
+    case prop of
+        Nil -> Nothing
+        Number control -> control |> Control.get |> Just
+        Coordinate control -> control |> Control.get |> Just
+        Text control -> control |> Control.get |> Just
+        Color control -> control |> Control.get |> Just
+        Toggle control -> control |> Control.get |> Just
+        Action control -> control |> Control.get |> Just
+        Choice _ _ control -> control |> Control.get |> Just
+        Group _ _ control -> control |> Control.get |> Just
+
+
+run : Property msg -> Cmd msg
+run prop =
     case prop of
         Nil -> Cmd.none
         Number control -> control |> Control.run
@@ -736,11 +750,12 @@ setFace face prop =
         _ -> prop
 
 
-toChoice : Property a -> Property a
-toChoice prop =
+toChoice : (ItemId -> a) -> Property a -> Property a
+toChoice f prop =
     case prop of
         Group focus shape control ->
             Choice focus shape
+                <| Control.mapByValue (.selected >> f)
                 <| Nest.toChoice
                 <| control
         _ -> prop

--- a/src/Tron/Property.elm
+++ b/src/Tron/Property.elm
@@ -205,7 +205,22 @@ unfold =
     fold (\path prop prev -> ( path, prop ) :: prev ) []
 
 
-andThen : (a -> Property a) -> Property a -> Property a
+fold1 : (a -> x) -> Property a -> Maybe x
+fold1 f prop =
+    case prop of
+        Nil -> Nothing
+        Number control -> control |> Control.fold f |> Just
+        Coordinate control -> control |> Control.fold f |> Just
+        Text control -> control |> Control.fold f |> Just
+        Color control -> control |> Control.fold f |> Just
+        Toggle control -> control |> Control.fold f |> Just
+        Action control -> control |> Control.fold f |> Just
+        Choice _ _ control -> control |> Control.fold f |> Just
+        Group _ _ control -> control |> Control.fold f |> Just
+
+
+
+andThen : (a -> Property b) -> Property a -> Property b
 -- FIXME: should be changed to `andThen` with getting rid of function in Control
 andThen f prop =
     case prop of
@@ -221,7 +236,7 @@ andThen f prop =
 
 
 
-with : (a -> Property a -> Property a) -> Property a -> Property a
+with : (a -> Property a -> Property b) -> Property a -> Property b
 -- FIXME: should be changed to `andThen` with getting rid of function in Control
 with f prop =
     andThen (\v -> f v prop) prop

--- a/src/Tron/Render/Layout.elm
+++ b/src/Tron/Render/Layout.elm
@@ -70,9 +70,9 @@ viewProperty
     -> State
     -> Path
     -> BoundsF
-    -> Maybe ( Label, Property msg )
+    -> Maybe ( Label, Property a )
     -> CellShape
-    -> ( Label, Property msg )
+    -> ( Label, Property a )
     -> Svg Msg_
 viewProperty
     theme
@@ -128,7 +128,7 @@ viewPlateControls
     -> Theme
     -> Path
     -> BoundsF
-    -> ( Label, Property msg )
+    -> ( Label, Property a )
     -> Svg Msg_
 viewPlateControls detach theme path pixelBounds ( label, source )  =
     positionAt_ pixelBounds <|
@@ -155,22 +155,22 @@ viewPagingControls path theme pixelBounds paging  =
 
 collectPlatesAndCells -- FIXME: a complicated function, split into many
     :  Dock
-    -> ( Path, Property msg )
+    -> ( Path, Property a )
     -> Layout
     ->
         ( List
             { path : Path
             , label : String
             , bounds : BoundsF
-            , source : Property msg
+            , source : Property a
             , pages : Pages.Count
             }
         , List
             { path : Path
             , label : String
             , bounds : BoundsF
-            , parent : Maybe (Property msg)
-            , source : Property msg
+            , parent : Maybe (Property a)
+            , source : Property a
             , index : Maybe Int
             }
         )
@@ -252,7 +252,7 @@ view
     -> BoundsF
     -> Detach.State
     -> Detach.GetAbility
-    -> Property msg
+    -> Property a
     -> Layout
     -> Html Msg_
 view theme dock bounds detach getDetachAbility root layout =

--- a/src/Tron/Render/Plate.elm
+++ b/src/Tron/Render/Plate.elm
@@ -52,7 +52,7 @@ controls
     -> Theme
     -> Path
     -> BoundsF
-    -> ( Label, Property msg )
+    -> ( Label, Property a )
     -> Svg Msg_
 controls detachAbility theme path bounds ( label, prop ) =
     Svg.g

--- a/src/Tron/Util.elm
+++ b/src/Tron/Util.elm
@@ -1,6 +1,7 @@
 module Tron.Util exposing (..)
 
 import Array exposing (Array)
+import Task
 
 
 -- import Bounds exposing (Bounds)
@@ -66,3 +67,12 @@ alter { min, max, step } amount curValue =
         toAdd = amount * (max - min)
         alignedByStep = toFloat (floor (toAdd / step)) * step
     in min + alignedByStep
+
+
+runMaybe : Maybe msg -> Cmd msg
+runMaybe maybeMsg =
+    case maybeMsg of
+        Just msg ->
+            Task.succeed msg
+                |> Task.perform identity
+        Nothing -> Cmd.none

--- a/src/Tron/Util.elm
+++ b/src/Tron/Util.elm
@@ -76,3 +76,41 @@ runMaybe maybeMsg =
             Task.succeed msg
                 |> Task.perform identity
         Nothing -> Cmd.none
+
+
+zipArrays : Array a -> Array b -> Array ( Maybe a, Maybe b )
+zipArrays arrayA arrayB =
+    if Array.length arrayA >= Array.length arrayB then
+        arrayA |>
+            Array.indexedMap
+                (\index valueA ->
+                    ( Just valueA, Array.get index arrayB )
+                )
+    else
+        arrayB |>
+            Array.indexedMap
+                (\index valueB ->
+                    ( Array.get index arrayA, Just valueB )
+                )
+
+
+zip3Arrays : Array a -> Array b -> Array c -> Array ( Maybe a, Maybe b, Maybe c )
+zip3Arrays arrayA arrayB arrayC =
+    if Array.length arrayC < Array.length arrayA || Array.length arrayC < Array.length arrayB then
+        zipArrays arrayA arrayB
+            |> Array.indexedMap
+                (\index ( maybeValueA, maybeValueB ) ->
+                    ( maybeValueA, maybeValueB, Array.get index arrayC )
+                )
+    else if Array.length arrayA >= Array.length arrayB then
+        zipArrays arrayA arrayC
+            |> Array.indexedMap
+                (\index ( maybeValueA, maybeValueC ) ->
+                    ( maybeValueA, Array.get index arrayB, maybeValueC )
+                )
+    else
+        zipArrays arrayB arrayC
+            |> Array.indexedMap
+                (\index ( maybeValueB, maybeValueC ) ->
+                    ( Array.get index arrayA, maybeValueB, maybeValueC )
+                )

--- a/src/WithTron.elm
+++ b/src/WithTron.elm
@@ -214,7 +214,7 @@ update ( userUpdate, userFor ) ports withTronMsg ( model, state, prevTree ) =
                 , state
                 , userFor newUserModel
                     |> Property.transferTransientState prevTree
-                    --|> Core.loadValues prevTree
+                    |> Property.loadValues prevTree
                     |> Core.invalidate
                 )
             , userEffect |> Cmd.map ToUser
@@ -234,6 +234,7 @@ update ( userUpdate, userFor ) ports withTronMsg ( model, state, prevTree ) =
                         [ {- guiEffect
                             |> Cmd.map ToUser -}
                         ]
+
                     )
 
         ReceiveRaw rawUpdate ->

--- a/src/WithTron.elm
+++ b/src/WithTron.elm
@@ -472,7 +472,7 @@ element
 element renderTarget ports def =
     Browser.element
         { init =
-            init ( def.init, def.for ) Nothing renderTarget ports
+            init ( def.init, def.for >> Core.invalidate ) Nothing renderTarget ports
         , update =
             update ( def.update, def.for ) ports
         , view =
@@ -529,11 +529,11 @@ document renderTarget ports def =
     Browser.document
         { init =
             \flags ->
-                init ( def.init, def.for ) Nothing renderTarget ports flags
+                init ( def.init, def.for >> Core.invalidate) Nothing renderTarget ports flags
         , update =
             update ( def.update, def.for ) ports
         , view =
-            \(userModel, gui) ->
+            \(userModel, state, tree) ->
                 { title = (def.view userModel).title
                 , body =
                     [ view
@@ -542,7 +542,7 @@ document renderTarget ports def =
                             Html.div [] <| (def.view umodel).body
                         )
                         renderTarget
-                        (userModel, gui)
+                        (userModel, state, tree)
                     ]
                 }
         , subscriptions =
@@ -612,11 +612,11 @@ application renderTarget ports def =
     Browser.application
         { init =
             \flags url _ ->
-                init ( def.init, def.for ) (Just url) renderTarget ports flags
+                init ( def.init, def.for >> Core.invalidate ) (Just url) renderTarget ports flags
         , update =
             update ( def.update, def.for ) ports
         , view =
-            \(userModel, gui) ->
+            \(userModel, state, tree) ->
                 let userView = def.view userModel
                 in
                     { title = userView.title
@@ -627,7 +627,7 @@ application renderTarget ports def =
                                 Html.div [] <| userView.body
                             )
                             renderTarget
-                            (userModel, gui)
+                            (userModel, state, tree)
                         ]
                     }
         , subscriptions =

--- a/src/WithTron.elm
+++ b/src/WithTron.elm
@@ -214,6 +214,7 @@ update ( userUpdate, userFor ) ports withTronMsg ( model, state, prevTree ) =
                 , state
                 , userFor newUserModel
                     |> Property.transferTransientState prevTree
+                    --|> Core.loadValues prevTree
                     |> Core.invalidate
                 )
             , userEffect |> Cmd.map ToUser

--- a/src/WithTron/Backed.elm
+++ b/src/WithTron/Backed.elm
@@ -42,6 +42,7 @@ import Dict.Extra as Dict
 import Html exposing (Html)
 
 import Tron exposing (Tron)
+import TronRef as Ref
 import WithTron exposing (..)
 import WithTron.ValueAt exposing (ValueAt)
 
@@ -115,8 +116,8 @@ byJson renderTarget ( ack, transmit ) tree =
         tree_ : Tron BackedMsg
         tree_ = tree |> Exp.toExposed |> Property.map Tuple.first
 
-        for_ : BackedStorage -> Tron BackedMsg
-        for_ dict = tree_ |> Exp.loadJsonValues dict
+        for_ : BackedStorage -> Ref.Tron BackedMsg
+        for_ dict = tree_ |> Exp.loadJsonValues dict |> Exp.lift
 
         init_ : () -> ( BackedStorage, Cmd BackedMsg )
         init_ _ = ( Dict.empty, Cmd.none )
@@ -208,8 +209,8 @@ byStrings renderTarget transmit tree =
         tree_ : Tron StringBackedMsg
         tree_ = tree |> Exp.toStrExposed |> Property.map Tuple.first
 
-        for_ : StringBackedStorage -> Tron StringBackedMsg
-        for_ dict = tree_ |> Exp.loadValues dict
+        for_ : StringBackedStorage -> Ref.Tron StringBackedMsg
+        for_ dict = tree_ |> Exp.loadValues dict |> Exp.lift
 
         init_ : () -> ( StringBackedStorage, Cmd StringBackedMsg )
         init_ _ = ( Dict.empty, Cmd.none )
@@ -326,13 +327,14 @@ byProxyApp renderTarget ( ack, transmit ) def =
         repair ( ( path, labelPath ), ( proxy, userMsg ) ) =
             ( Just ( Path.toList path, labelPath, proxy ), userMsg )
 
-        for_ : ( ProxyBackedStorage, model ) -> Tron ( ProxyBackedMsg, msg )
+        for_ : ( ProxyBackedStorage, model ) -> Ref.Tron ( ProxyBackedMsg, msg )
         for_ ( dict, model ) =
             def.for (toValueAt dict) model
                 |> Exp.toProxied
                 |> Exp.loadProxyValues ( dictByPath dict )
                 |> Property.addPaths
                 |> Tron.map repair
+                |> Exp.lift
 
         init_ : flags -> ( ( ProxyBackedStorage, model ), Cmd ( ProxyBackedMsg, msg ) )
         init_ flags =


### PR DESCRIPTION
The major core rewrite, so we only use handler functions when it's needed and don't store them in the model etc..